### PR TITLE
Missing English string in Time registration page

### DIFF
--- a/ProjectManagement/lang/strings_english.txt
+++ b/ProjectManagement/lang/strings_english.txt
@@ -29,7 +29,7 @@
 	$s_plugin_ProjectManagement_day = 'Today';
 	$s_plugin_ProjectManagement_week = 'This week';
 	$s_plugin_ProjectManagement_last_week = 'Last week';
-	$s_plugin_ProjectManagement_last_month = 'Last months';
+	$s_plugin_ProjectManagement_last_months = 'Last months';
 	$s_plugin_ProjectManagement_month = 'Month';
 	$s_plugin_ProjectManagement_unassigned = 'Unassigned';
 	


### PR DESCRIPTION
$s_plugin_ProjectManagement_last_months was missing the final 's' in
strings_english.txt
