### PR TITLE
Follow the EVENT_TYPE_CHAIN contract

### DIFF
--- a/ProjectManagement/ProjectManagement.php
+++ b/ProjectManagement/ProjectManagement.php
@@ -481,6 +481,8 @@ class ProjectManagementPlugin extends MantisPlugin {
 				}
 			}
 		}
+
+		return $p_bug_data;
 	}
 
 	function view_bug_pm_summary( $p_event, $p_bug_id ) {


### PR DESCRIPTION
As per the documentation, the EVENT_TYPE_CHAIN should always return the first set of parameters (http://www.mantisbt.org/docs/master/en/developers/dev.events.types.html#DEV.EVENTS.TYPES.CHAIN).

In this current implementation, the event EVENT_UPDATE_BUG is not usable by any other plugin once ProjectManagement has used it.

This is because the chaining of the first set of parameters is not done by the update_bug function, which corrupts the value of those parameters for any following hooked functions.
